### PR TITLE
Get device through ID, instead of list order

### DIFF
--- a/tradfri.py
+++ b/tradfri.py
@@ -6,14 +6,12 @@ import pytradfri
 import argparse
 
 IP = '192.168.1.129'
-KEY = 'tuGqA6Er3snmeWsB'
+KEY = 'NOT_REAL'
 
 whiteTemps = {"cold":"f5faf6", "normal":"f1e0b5", "warm":"efd275"}
 
 api = pytradfri.coap_cli.api_factory(IP, KEY)
 gateway = pytradfri.gateway.Gateway(api)
-devices = gateway.get_devices()
-lights = [dev for dev in devices if dev.has_light_control]
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--gateway", "-g", default=IP)
@@ -35,16 +33,16 @@ parser_colortemp.add_argument("value", choices=['cold', 'normal', 'warm'])
 
 args = parser.parse_args()
 
+device = gateway.get_device(int(args.id))
+
 if args.command == "on":
-    #lights[int(args.id)].light_control.set_dimmer(50)
-    lights[int(args.id)].light_control.set_state(True)
+    device.light_control.set_state(True)
 
 if args.command == "off":
-    #lights[int(args.id)].light_control.set_dimmer(0)
-    lights[int(args.id)].light_control.set_state(False)
+    device.light_control.set_state(False)
 
 if args.command == "level":
-    lights[int(args.id)].light_control.set_dimmer(int(args.value))
+    device.light_control.set_dimmer(int(args.value))
 
 if args.command == "whitetemp":
-    lights[int(args.id)].light_control.set_hex_color(whiteTemps[args.value])
+    device.light_control.set_hex_color(whiteTemps[args.value])


### PR DESCRIPTION
Instead of getting every light and use the array position, and risk the order changing, just use the get_device function with the 5 digit device ID.

Also removed the key as real keys really shouldn't be on github.


This will break existing integrations, as the ID changes, but they'd break eventually anyway, if the device sorting order in the gateway changes.